### PR TITLE
Allow export only for distributions still in development

### DIFF
--- a/news/28.feature
+++ b/news/28.feature
@@ -1,0 +1,1 @@
+Allow export only for distributions still in development [@ericof]

--- a/src/plone/distribution/exportimport/configure.zcml
+++ b/src/plone/distribution/exportimport/configure.zcml
@@ -9,7 +9,7 @@
   <include package="collective.exportimport" />
 
   <browser:page
-      name="import_all"
+      name="dist_import_all"
       for="*"
       class=".exportimport.ImportAll"
       template="templates/import_all.pt"
@@ -17,7 +17,7 @@
       />
 
   <browser:page
-      name="export_all"
+      name="dist_export_all"
       for="*"
       class=".exportimport.ExportAll"
       template="templates/export_all.pt"
@@ -25,7 +25,7 @@
       />
 
   <browser:page
-      name="import_content"
+      name="dist_import_content"
       for="plone.base.interfaces.siteroot.IPloneSiteRoot"
       class=".exportimport.ImportContent"
       permission="cmf.ManagePortal"

--- a/src/plone/distribution/exportimport/templates/export_all.pt
+++ b/src/plone/distribution/exportimport/templates/export_all.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       metal:use-macro="context/main_template/macros/master"
-      i18n:domain="plone.z3cform"
+      i18n:domain="plone.distribution"
 >
 
   <div metal:fill-slot="main">
@@ -11,13 +11,13 @@
 
       <h1 class="documentFirstHeading"
           i18n:translate=""
-      >Export all</h1>
+      >Export current site to a distribution</h1>
 
       <p class="documentDescription"
          i18n:translate=""
       >Exports the site as json.</p>
 
-      <form action="@@export_all"
+      <form action="@@export_dist_all"
             enctype="multipart/form-data"
             method="post"
             tal:attributes="

--- a/src/plone/distribution/exportimport/templates/import_all.pt
+++ b/src/plone/distribution/exportimport/templates/import_all.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       metal:use-macro="context/main_template/macros/master"
-      i18n:domain="plone.z3cform"
+      i18n:domain="plone.distribution"
 >
 
   <div metal:fill-slot="main">
@@ -11,7 +11,7 @@
 
       <h1 class="documentFirstHeading"
           i18n:translate=""
-      >Import all</h1>
+      >Import Distribution Data</h1>
 
       <p class="documentDescription"
          i18n:translate=""

--- a/src/plone/distribution/handler.py
+++ b/src/plone/distribution/handler.py
@@ -30,6 +30,6 @@ def default_handler(
             # If there is no savepoint most tests fail with a PosKeyError
             transaction.savepoint(optimistic=True)
             request = getRequest() or site.REQUEST
-            import_all = api.content.get_view("import_all", site, request)
+            import_all = api.content.get_view("dist_import_all", site, request)
             import_all(content_json_path)
     return site


### PR DESCRIPTION
Closes #28 
- [X]  Check for environment variable DEVELOP_DISTRIBUTIONS to filter distributions that could be "exported" to
- [X]  Rename exportimport browser views used in this package to avoid a name clash