### PR TITLE
Fix logic for suggested id for new site.

### DIFF
--- a/news/97.bugfix
+++ b/news/97.bugfix
@@ -1,0 +1,3 @@
+Fix logic for suggested id for new site.
+It could suggest an id that was already taken.
+@mauritsvanrees

--- a/src/plone/distribution/services/sites/get.py
+++ b/src/plone/distribution/services/sites/get.py
@@ -90,10 +90,18 @@ class SitesGet(Service):
         request = self.request
         # Sites with default id
         all_sites = self.get_sites()
-        sites = [site for site in all_sites if site["id"].startswith(DEFAULT_ID)]
-        server_defaults["site_id"] = (
-            f"{DEFAULT_ID}{len(sites)}" if sites else DEFAULT_ID
-        )
+        site_ids = [
+            site["id"] for site in all_sites if site["id"].startswith(DEFAULT_ID)
+        ]
+        if site_ids:
+            count = len(site_ids)
+            new_site_id = f"{DEFAULT_ID}{count}"
+            while new_site_id in site_ids:
+                count += 1
+                new_site_id = f"{DEFAULT_ID}{count}"
+        else:
+            new_site_id = DEFAULT_ID
+        server_defaults["site_id"] = new_site_id
         jsonschema = distribution.schema
         uischema = distribution.uischema
         if should_provide_default_language_default(uischema, jsonschema):


### PR DESCRIPTION
This would take the default "Plone" plus the count of existing sites. Usually this works fine, first suggesting Plone, then Plone1, Plone2, etc. But if you have Plone and Plone2 as existing site ids, it would suggest Plone2, which gives an error because it is already taken.

The fix is: keep this logic, but if the id is already taken, keep increasing the id until it is free.

This fixes https://github.com/plone/plone.distribution/issues/97

I wondered why not more people were bitten by this. :-)