### PR TITLE
Include revisions only when passing --include-revisions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,10 +293,13 @@ Folder containing JSON data representing this distribution's content.
 To export content from a site into this folder, use the `bin/export-distribution` script.
 
 ```shell
-bin/export-distribution path/to/zope.conf Plone
+bin/export-distribution [--include-revisions] path/to/zope.conf Plone
 ```
 
 > In the example above, "Plone" is the ID of the Plone site to export.
+
+By default, the revisions history (older versions of each content item) are not exported.
+If you do want them, add `--include-revisions` on the command line.
 
 ## Advanced Usage
 

--- a/news/39.feature
+++ b/news/39.feature
@@ -1,0 +1,1 @@
+Include revisions only when passing `--include-revisions`.  @mauritsvanrees

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "plone.api",
         "plone.base",
         "plone.dexterity",
-        "plone.exportimport>=1.0.0a5",
+        "plone.exportimport>=1.0.0b1",
         "plone.i18n",
         "plone.protect",
         "plone.rest",


### PR DESCRIPTION
This needs https://github.com/plone/plone.exportimport/pull/44. It would be good to have that merged and in a release, so we can add that release as minimum version in our dependencies.