### PR TITLE
Fixed #118: Removed deprecated plone.volto:default-homepage profile from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,11 @@ A 1080x768 image of your distribution. It could be the default page of a new sit
 
 A `JSON` file with the GenericSetup profiles that are used by your distribution during installation.
 
-This file needs to contain two keys:
+This file needs to contain at least one key:
 
 - **base**: List of profiles installed in every new site using this distribution.
 
-- **content**: List of profiles installed when the user decides to create a site with example content.
+- **content**: **Deprecated** List of profiles installed when the user decides to create a site with example content. Content creation is now handled through JSON import files in the `content/` directory using `plone.exportimport`.
 
 The configuration for a new Volto site is:
 
@@ -159,12 +159,11 @@ The configuration for a new Volto site is:
     "plone.app.caching:default",
     "plonetheme.barceloneta:default",
     "plone.volto:default"
-  ],
-  "content": [
-    "plone.volto:default-homepage"
   ]
 }
 ```
+
+**Note:** The `content` key is deprecated. Content creation is now handled through JSON import files in the `content/` directory using `plone.exportimport`.
 
 #### How to add an add-on
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ This file needs to contain at least one key:
 
 - **base**: List of profiles installed in every new site using this distribution.
 
-- **content**: **Deprecated** List of profiles installed when the user decides to create a site with example content. Content creation is now handled through JSON import files in the `content/` directory using `plone.exportimport`.
+> [!WARNING]
+> - **content**: _Deprecated_. List of profiles installed when the user decides to create a site with example content. Content creation is now handled through JSON import files in the `content/` directory using `plone.exportimport`.
 
 The configuration for a new Volto site is:
 
@@ -163,7 +164,6 @@ The configuration for a new Volto site is:
 }
 ```
 
-**Note:** The `content` key is deprecated. Content creation is now handled through JSON import files in the `content/` directory using `plone.exportimport`.
 
 #### How to add an add-on
 

--- a/news/99.bugfix
+++ b/news/99.bugfix
@@ -1,0 +1,1 @@
+Remove deprecated plone.volto:default-homepage profile from README recommendations. @thanu

--- a/news/99.bugfix
+++ b/news/99.bugfix
@@ -1,1 +1,1 @@
-Remove deprecated plone.volto:default-homepage profile from README recommendations. @thanu
+Remove deprecated `plone.volto:default-homepage` profile from `README.md` recommendations. @Thanush-03


### PR DESCRIPTION

   ## Description

This PR fixes issue #118 by removing the deprecated `plone.volto:default-homepage` profile from the README recommendations. This profile was removed from plone.volto in version 5, causing site creation failures when distributions followed the README guidance.

## Changes Made

- Remove deprecated `"plone.volto:default-homepage"` profile from the example `profiles.json` configuration
- Mark the `content` key as deprecated in the profiles.json documentation
- Add explanatory note about using JSON import files in the `content/` directory with `plone.exportimport`
- Update documentation to reflect the modern content creation approach

## Why This Was Needed

The `plone.volto:default-homepage` profile was removed from plone.volto version 5, but the README was still recommending its use. This caused site creation to fail when users followed the documentation and tried to create sites with content.

## Testing

- Verified that the README examples are now valid
- Confirmed that the documentation clearly explains the new approach
- No breaking changes to existing functionality

Closes #118
I, thanush_03, agree to have this contribution published under Creative Commons 4.0 International License (CC BY 4.0), with attribution to the Plone Foundation.